### PR TITLE
logging: write .log files under logs/ and ensure dir exists; move hyp…

### DIFF
--- a/scripts/benchmark_training.py
+++ b/scripts/benchmark_training.py
@@ -41,10 +41,16 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from hrm.config import HRMConfig
 from hrm.model import HRMModel
 
-# Configure logging
+# Configure logging (write under logs/)
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(LOG_DIR / "benchmark_training.log"),
+    ],
 )
 logger = logging.getLogger("benchmark_training")
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -57,10 +57,16 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from hrm.config import HRMConfig
 from hrm.model import HRMModel, create_hrm_model
 
-# Configure logging
+# Configure logging (write under logs/)
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(LOG_DIR / "evaluate.log"),
+    ],
 )
 logger = logging.getLogger(__name__)
 

--- a/scripts/reliability_monitor.py
+++ b/scripts/reliability_monitor.py
@@ -21,7 +21,6 @@ import json
 import logging
 import os
 import platform
-import psutil
 import signal
 import subprocess
 import sys
@@ -34,25 +33,28 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+import psutil
 import torch
 import yaml
 
-# Configure logging
+# Configure logging (ensure logs/ exists)
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
         logging.StreamHandler(),
-        logging.FileHandler("logs/reliability_monitor.log"),
+        logging.FileHandler(LOG_DIR / "reliability_monitor.log"),
     ],
 )
 logger = logging.getLogger("reliability_monitor")
 
 # Constants
 DEFAULT_CONFIG_PATH = "configs/m1_optimized_training.yaml"
-HEARTBEAT_PATH = "logs/heartbeat.txt"
-ALERT_LOG_PATH = "logs/alerts.log"
-BENCHMARK_RESULTS_PATH = "logs/benchmark_results.json"
+HEARTBEAT_PATH = str(LOG_DIR / "heartbeat.txt")
+ALERT_LOG_PATH = str(LOG_DIR / "alerts.log")
+BENCHMARK_RESULTS_PATH = str(LOG_DIR / "benchmark_results.json")
 RECOVERY_SCRIPT_PATH = "scripts/recover.sh"
 MPS_MEMORY_THRESHOLD = 0.9  # 90% of available memory
 CPU_THRESHOLD = 0.9  # 90% CPU usage
@@ -1228,8 +1230,8 @@ def main():
     elif args.mode == "benchmark":
         # Import HRM model for benchmarking
         try:
-            from hrm.model import HRMModel
             from hrm.config import get_default_mbpp_config
+            from hrm.model import HRMModel
 
             config = get_default_mbpp_config()
             model = HRMModel(config)


### PR DESCRIPTION
…othesis logs to logs/. training: make checkpoints weights-only friendly for torch>=2.6 (store config/state as plain dicts) and keep tests green

# Pull Request Checklist

## Summary
- Briefly describe the change and motivation.
- Link docs or tracking (e.g., `docs/SDLC_TRACKING.md`).

## Related Issues
- Closes #<issue-id>

## Type of Change
- [ ] feat
- [ ] fix
- [ ] docs
- [ ] chore/refactor
- [ ] ci/devops

## Test Coverage
- [ ] Tests added/updated
- [ ] Ran `pytest -q`: PASS
- [ ] Tokenizer cache handled (see README Testing)

## Screenshots / Artifacts (training/eval)
- Logs/plots (loss, pass@k). Checkpoint(s): `checkpoints/...`

## Backward Compatibility
- [ ] No breaking config changes
- [ ] If breaking, include migration notes

## Quality Gates
- [ ] `black . && isort .`
- [ ] `flake8` clean
- [ ] Docs updated if user-facing behavior changed

## Operational / Security
- [ ] No secrets committed (`GITHUB_SECRETS_SETUP.md`)
- [ ] Large artifacts kept out of VCS (`data/`, `checkpoints/`, `outputs/`)

## How to Validate (copy‑paste)
```bash
python -m venv .venv && source .venv/bin/activate
pip install -r requirements.txt
pytest -q
# Optional data/train/eval
python scripts/convert_mbpp.py --split all --output-dir data/mbpp --tokenizer gpt2
python scripts/train.py --config configs/hrm/mbpp_base.yaml \
  --data-path data/mbpp/train.bin --eval-data-path data/mbpp/validation.bin \
  --output-dir checkpoints/hrm-mbpp
python scripts/evaluate.py --ckpt checkpoints/hrm-mbpp/latest.pt --split test --k 1 5 10
```
