### PR TITLE
fix(trainer): initialize LR to 0 during warmup by stepping scheduler …

### DIFF
--- a/training/trainer.py
+++ b/training/trainer.py
@@ -280,6 +280,11 @@ class Trainer:
         self.optimizer = self.create_optimizer()
         self.scheduler = self.create_scheduler()
 
+        # Ensure LR starts at 0.0 during warmup so initial optimizer group LR
+        # and scheduler-reported LR match test expectations
+        if self.config.warmup_steps > 0:
+            self.scheduler.step(0)
+
         # Setup mixed precision training
         self.scaler = GradScaler() if config.fp16 else None
 


### PR DESCRIPTION
Summary: Ensure initial LR is 0.0 when warmup is enabled so optimizer group LR and scheduler last LR match expectations.
Rationale: Tests assert warmup LR behavior; this aligns trainer init with those expectations.
Change: Call scheduler.step(0) during Trainer init when warmup_steps > 0.
Tests: Ran pytest -q locally; all tests passed.
Risk: Minimal. Only affects initial LR reporting during warmup.
Follow-ups: Address deprecation warnings (MPS check, autocast) in a separate PR.