### PR TITLE
feat(eval): explicit warning and model_source flag when Sapient HRM is not used

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@ Please update any bookmarks or links.
   - Add `scripts/quick_eval_codegen.py` to run a small MBPP dev slice (e.g., 25 tasks) using `hrm_codegen/` and report Pass@1 and latency.
   - Use subprocess-based execution (no Docker) for safety; no training refactors.
   - Acceptance: single command prints Pass@1, average latency; runs on CPU/MPS/CUDA.
+  - See `docs/CODEGEN_EVAL_PLAN.md` for exact commands, outputs, and acceptance criteria.
 - Fix generation correctness/perf in `hrm/HRMModel`
   - Respect `attention_mask` throughout forward/generation and apply hierarchical masks (`get_hierarchical_mask`).
   - Implement proper incremental decoding/KV-state caching (avoid full re-forward each step).

--- a/docs/reference/technical-specification.md
+++ b/docs/reference/technical-specification.md
@@ -71,11 +71,26 @@ Phase 2 outputs:
 ## 4. Technical Implementation Details
 
 1. **Tokenizer**  
+   ```python
+   from tokenization import get_tokenizer, encode, decode
+
+   tok = get_tokenizer()
+   # Cache lives under checkpoints/tokenizer; corrupted cache is auto-repaired
+
+   # Encoding with explicit BOS/EOS support and attention_mask maintenance
+   batch = encode(
+       ["def add(a, b):", "return a + b"],
+       add_bos=True,
+       add_eos=True,
+       max_length=64,
+       return_tensors="pt",
+   )
+   # batch contains input_ids and attention_mask aligned to max_length
+
+   # Decoding safely handles empty inputs
+   text = decode([])  # ""
    ```
-   from transformers import AutoTokenizer  
-   tok = AutoTokenizer.from_pretrained("gpt2", add_bos_token=True)  
-   ```
-   Save vocab JSON to `checkpoints/tokenizer.json`; freeze during training.
+   The tokenizer is saved to `checkpoints/tokenizer/` and reused across runs.
 
 2. **Embedding Path**  
    ```python

--- a/external/README.md
+++ b/external/README.md
@@ -22,6 +22,9 @@ external/
 We keep the upstream code **unaltered**; all adaptation layers live in our own source tree.  
 If fixes or changes are required, contribute them upstream or patch via a separate directory, never commit them directly inside `external/sapient-hrm`.
 
+### Visibility in tooling
+- The script `scripts/quick_eval_codegen.py` will print a WARNING and include a `model_source` field in its JSON summary when the Sapient HRM is not used (i.e., when falling back to the mock). This makes non-HRM runs immediately obvious in logs and artifacts.
+
 ## Git & CI notes
 
 * Large checkpoints and build artefacts should be excluded via `.gitignore`.

--- a/scripts/quick_eval_codegen.py
+++ b/scripts/quick_eval_codegen.py
@@ -91,6 +91,7 @@ def run_quick_eval(args: argparse.Namespace) -> Dict[str, Any]:
     # Try to load Sapient-HRM CodeGen; fall back to mock model if unavailable
     codegen_cfg = None
     model = None
+    model_source = "unknown"
     try:
         # Defer heavy imports to runtime to catch missing vendor cleanly
         from hrm_codegen.config import load_config as load_codegen_config  # type: ignore
@@ -99,8 +100,15 @@ def run_quick_eval(args: argparse.Namespace) -> Dict[str, Any]:
         codegen_cfg = load_codegen_config(args.config)
         model = HRMCodeGenerator.from_config(codegen_cfg).to(device)
         model.eval()
+        model_source = "sapient_hrm"
     except Exception as e:
         # Fallback to mock model for a smoke test when Sapient HRM isn't present
+        model_source = "mock"
+        print(
+            "WARNING: Using MockHRMModel fallback instead of Sapient HRM. "
+            "To use the real HRM, clone the upstream into external/sapient-hrm or install the package 'sapient_hrm' in your environment.",
+            file=sys.stderr,
+        )
         mock_cfg = MockHRMConfig(
             hidden_size=256,
             num_hidden_layers=4,
@@ -175,9 +183,10 @@ def run_quick_eval(args: argparse.Namespace) -> Dict[str, Any]:
         "temperature": args.temperature,
         "top_p": args.top_p,
         "top_k": args.top_k,
+        "model_source": model_source,
     }
 
-    # Print concise summary
+    # Print concise summary (always include model source)
     print(json.dumps(summary, indent=2))
 
     # Save detailed results


### PR DESCRIPTION
## Summary
- Print a clear stderr WARNING when quick eval falls back to MockHRMModel (Sapient HRM not available).
- Include `model_source` in JSON summary: `sapient_hrm` or `mock`.
- Update `external/README.md` documenting this visibility.

## Why
The project’s core goal is to demonstrate HRM modified for code gen. Any non-HRM run must be obvious in logs and artifacts.

## Test Plan
- `pytest -q` passes locally.
- Run quick eval without Sapient HRM present; observe:
  - Stderr WARNING
  - `model_source: "mock"` in printed JSON.
- With Sapient HRM installed/vendor present; observe `model_source: "sapient_hrm"` and no WARNING.

## Notes
This is additive and safe; no change to generation logic.