### PR TITLE
ci: add lint/type/security jobs + CODEOWNERS and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zshinyg

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,49 +1,17 @@
-# Pull Request Checklist
-
 ## Summary
-- Briefly describe the change and motivation.
-- Link docs or tracking (e.g., `docs/SDLC_TRACKING.md`).
 
-## Related Issues
-- Closes #<issue-id>
+- 
 
-## Type of Change
-- [ ] feat
-- [ ] fix
-- [ ] docs
-- [ ] chore/refactor
-- [ ] ci/devops
+## Type of change
+- [ ] Fix
+- [ ] Feature
+- [ ] Docs
+- [ ] CI/Security
 
-## Test Coverage
-- [ ] Tests added/updated
-- [ ] Ran `pytest -q`: PASS
-- [ ] Tokenizer cache handled (see README Testing)
+## Test plan
+- 
 
-## Screenshots / Artifacts (training/eval)
-- Logs/plots (loss, pass@k). Checkpoint(s): `checkpoints/...`
-
-## Backward Compatibility
-- [ ] No breaking config changes
-- [ ] If breaking, include migration notes
-
-## Quality Gates
-- [ ] `black . && isort .`
-- [ ] `flake8` clean
-- [ ] Docs updated if user-facing behavior changed
-
-## Operational / Security
-- [ ] No secrets committed (`GITHUB_SECRETS_SETUP.md`)
-- [ ] Large artifacts kept out of VCS (`data/`, `checkpoints/`, `outputs/`)
-
-## How to Validate (copy‑paste)
-```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-pytest -q
-# Optional data/train/eval
-python scripts/convert_mbpp.py --split all --output-dir data/mbpp --tokenizer gpt2
-python scripts/train.py --config configs/hrm/mbpp_base.yaml \
-  --data-path data/mbpp/train.bin --eval-data-path data/mbpp/validation.bin \
-  --output-dir checkpoints/hrm-mbpp
-python scripts/evaluate.py --ckpt checkpoints/hrm-mbpp/latest.pt --split test --k 1 5 10
-```
+## Checklist
+- [ ] Conventional commit title
+- [ ] Tests pass locally
+- [ ] Docs updated (if needed)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,34 +7,79 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - run: |
+          python -m pip install -U pip
+          pip install ruff==0.5.7 black==23.12.1 isort==5.13.2
+      - name: Ruff
+        run: ruff check .
+      - name: Black (check)
+        run: black --check .
+      - name: isort (check)
+        run: isort --check-only .
 
-      - name: Cache pip
-        uses: actions/cache@v4
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: |
+          python -m pip install -U pip
+          pip install pyright==1.1.387
+      - name: Pyright
+        run: npx pyright
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           pip install -r requirements.txt
-
       - name: HRM presence guard (PRs only)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           python scripts/check_hrm_usage.py || echo "HRM not present; guard will fail only in required HRM jobs"
-
       - name: Run tests
         run: pytest -q
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: detect --source=. --no-banner --redact --report-format sarif --report-path gitleaks.sarif
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif
+
+  codeql:
+    uses: github/codeql-action/.github/workflows/codeql.yml@v3
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Lint: Ruff, Black (check), isort (check)
- Typecheck: Pyright (via npx)
- Tests: Python 3.10 and 3.11 matrix, cached pip, optional HRM guard
- Security: Gitleaks with SARIF upload; CodeQL workflow reuse
- Repo hygiene: CODEOWNERS (solo), PR template

## Notes
- As a public solo project, branch protection + required checks can be enabled on main: lint, typecheck, test, security.
